### PR TITLE
Make the radius parameter optional

### DIFF
--- a/example/main.dart
+++ b/example/main.dart
@@ -5,12 +5,12 @@ main() async {
   LatLng l1 = LatLng(50.06638889, 5.71472222);
   LatLng l2 = LatLng(58.64388889, 3.07000000);
 
-  num distance = geodesy.distanceBetweenTwoGeoPoints(l1, l2, null);
+  num distance = geodesy.distanceBetweenTwoGeoPoints(l1, l2);
   print("[distanceBetweenTwoGeoPoints] Distance: " + distance.toString());
 
   LatLng l3 = LatLng(51.4778, -0.0015);
   LatLng distinationPoint =
-      geodesy.destinationPointByDistanceAndBearing(l3, 7794.0, 300.7, null);
+      geodesy.destinationPointByDistanceAndBearing(l3, 7794.0, 300.7);
   print("[destinationPointByDistanceAndBearing] Lat: " +
       distinationPoint.latitude.toString());
   print("[destinationPointByDistanceAndBearing] Lng: " +
@@ -42,7 +42,7 @@ main() async {
       "[intersectionByPaths] Lng: " + intersectionByPaths.longitude.toString());
 
   LatLng l6 = LatLng(50.587, 1.231);
-  num distanceToGreatCircle = geodesy.crossTrackDistanceTo(l4, l5, l6, null);
+  num distanceToGreatCircle = geodesy.crossTrackDistanceTo(l4, l5, l6);
   print("[crossTrackDistanceTo] :" + distanceToGreatCircle.toString());
 
   List<LatLng> poly = [

--- a/lib/src/geodesy.dart
+++ b/lib/src/geodesy.dart
@@ -7,7 +7,8 @@ class Geodesy {
 
   /// calculate a destination point given the distance and bearing
   LatLng destinationPointByDistanceAndBearing(
-      LatLng l, num distance, num bearing, num radius) {
+      LatLng l, num distance, num bearing,
+      [num radius]) {
     radius = radius ?? RADIUS;
 
     num angularDistanceRadius = distance / radius;
@@ -113,7 +114,7 @@ class Geodesy {
   }
 
   /// calculate the distance in meters between two geo points
-  num distanceBetweenTwoGeoPoints(LatLng l1, LatLng l2, num radius) {
+  num distanceBetweenTwoGeoPoints(LatLng l1, LatLng l2, [num radius]) {
     radius = radius ?? RADIUS;
     num R = radius;
     num l1LatRadians = degToRadian(l1.latitude);
@@ -155,7 +156,7 @@ class Geodesy {
   }
 
   /// calculate signed distance from a geo point to greate circle with start and end points
-  num crossTrackDistanceTo(LatLng l1, LatLng start, LatLng end, num radius) {
+  num crossTrackDistanceTo(LatLng l1, LatLng start, LatLng end, [num radius]) {
     num R = radius ?? RADIUS;
 
     num distStartL1 = distanceBetweenTwoGeoPoints(start, l1, R) / R;


### PR DESCRIPTION
Instead of typing

```dart
geodesy.distanceBetweenTwoGeoPoints(l1, l2, null);
```

we can type

```dart
geodesy.distanceBetweenTwoGeoPoints(l1, l2);
```