### PR TITLE
Release: 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.11.0
+
+- Updated min sdk version to 3.2.0
+- Bumped dev_dependencies (lints & test)
+- Bumped dependencies (latlong2)
+
 ## 0.10.2 
 
 - Fixed Shoelace formula

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   latlong2: ^0.9.0
 
 dev_dependencies:
-  lints: ^5.0.0
+  lints: ^6.0.0
   test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: geodesy
 description: A Dart library for geodesic and trigonometric calculations working with points and paths
-version: 0.10.2
+version: 0.11.0
 homepage: https://github.com/wingkwong/geodesy
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.2.0 <4.0.0'
 
 dependencies:
   latlong2: ^0.10.0
 
 dev_dependencies:
   lints: ^6.0.0
-  test: ^1.16.8
+  test: ^1.31.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   latlong2: ^0.9.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0
   test: ^1.16.8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  latlong2: ^0.9.0
+  latlong2: ^0.10.0
 
 dev_dependencies:
   lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   latlong2: ^0.9.0
 
 dev_dependencies:
-  lints: ^4.0.0
+  lints: ^5.0.0
   test: ^1.16.8


### PR DESCRIPTION
This pull request updates the package to version 0.11.0, focusing on dependency and SDK version upgrades to ensure compatibility and maintainability.

Dependency and SDK updates:

* Increased the minimum Dart SDK version to `3.2.0` in `pubspec.yaml` to support newer language features and maintain compatibility.
* Upgraded the `latlong2` dependency to version `^0.10.0` in `pubspec.yaml`.
* Updated development dependencies: `lints` to `^6.0.0` and `test` to `^1.31.2` in `pubspec.yaml`.

Documentation:

* Added a new section for version 0.11.0 in `CHANGELOG.md` summarizing these updates.